### PR TITLE
Moved inner splitpane into jsh.ResourceEditor class

### DIFF
--- a/common-web/src/main/javascript/jsh/editor.js
+++ b/common-web/src/main/javascript/jsh/editor.js
@@ -25,8 +25,7 @@ goog.require('jsh.SplitPane');
 jsh.HackEditor = function(opt_domHelper) {
   goog.base(this, opt_domHelper);
 
-  this.outersplitpane_ = null;
-  this.innersplitpane_ = null;
+  this.splitpane_ = null;
 
   this.viewSizeMonitor_ = new goog.dom.ViewportSizeMonitor();
 
@@ -64,24 +63,15 @@ jsh.HackEditor.prototype.decorateInternal = function(element) {
   this.addChild(toolbar, true);
 
   this.lhs = new goog.ui.Component();
-//  this.editor = new jsh.AceEditor();
-//  this.details = new jsh.HackDetailsArea();
-//  this.props = new goog.ui.Component();
 
   this.editor = new jsh.ResourceEditor();
 
-//  this.innersplitpane_ = new jsh.SplitPane(this.details, this.props,
-//      goog.ui.SplitPane.Orientation.VERTICAL);
-//  this.innersplitpane_.setInitialSize(300);
-//  this.innersplitpane_.setHandleSize(this.splitPaneHandleWidth_);
-//  this.innersplitpane_.setSecondComponentStatic(true);
-
-  this.outersplitpane_ = new jsh.SplitPane(this.lhs, this.editor,
+  this.splitpane_ = new jsh.SplitPane(this.lhs, this.editor,
       goog.ui.SplitPane.Orientation.HORIZONTAL);
-  this.outersplitpane_.setInitialSize(300);
-  this.outersplitpane_.setHandleSize(this.splitPaneHandleWidth_);
+  this.splitpane_.setInitialSize(300);
+  this.splitpane_.setHandleSize(this.splitPaneHandleWidth_);
 
-  this.addChild(this.outersplitpane_, true);
+  this.addChild(this.splitpane_, true);
 };
 
 
@@ -91,28 +81,9 @@ jsh.HackEditor.prototype.decorateInternal = function(element) {
  */
 jsh.HackEditor.prototype.enterDocument = function() {
   goog.base(this, 'enterDocument');
-//  this.resizeOuterSplitPane_();
-//  goog.events.listen(this.viewSizeMonitor_,
-//      goog.events.EventType.RESIZE, this.resizeOuterSplitPane_, false, this);
-//  goog.events.listen(this.outersplitpane_, goog.ui.Component.EventType.CHANGE,
-//      this.resizeInnerSplitPane_, false, this);
-//  goog.events.listen(this.innersplitpane_, goog.ui.Component.EventType.CHANGE,
-//      goog.events.Event.stopPropagation, false, this);
-
-};
-
-
-/**
- * Handler for the viewSizeMonitor event, to resize the innerSplitPane
- * @private
- */
-jsh.HackEditor.prototype.resizeInnerSplitPane_ = function() {
-  var rhsheight = this.viewSizeMonitor_.getSize().height -
-      goog.style.getPosition(this.outersplitpane_.getElement()).y;
-  var rhswidth = this.viewSizeMonitor_.getSize().width -
-      this.outersplitpane_.getFirstComponentSize() - this.splitPaneHandleWidth_;
-  this.innersplitpane_.setSize(new goog.math.Size(rhswidth, rhsheight));
-//  this.editor.resize();
+  this.resizeOuterSplitPane_();
+  goog.events.listen(this.viewSizeMonitor_,
+      goog.events.EventType.RESIZE, this.resizeOuterSplitPane_, false, this);
 };
 
 
@@ -122,9 +93,8 @@ jsh.HackEditor.prototype.resizeInnerSplitPane_ = function() {
  */
 jsh.HackEditor.prototype.resizeOuterSplitPane_ = function() {
   var lhsheight = this.viewSizeMonitor_.getSize().height -
-      goog.style.getPosition(this.outersplitpane_.getElement()).y;
+      goog.style.getPosition(this.splitpane_.getElement()).y;
   var lhswidth = this.viewSizeMonitor_.getSize().width;
-  this.outersplitpane_.setSize(new goog.math.Size(lhswidth, lhsheight));
-  this.resizeInnerSplitPane_();
+  this.splitpane_.setSize(new goog.math.Size(lhswidth, lhsheight));
 };
 

--- a/common-web/src/main/javascript/jsh/resourceeditor.js
+++ b/common-web/src/main/javascript/jsh/resourceeditor.js
@@ -26,6 +26,9 @@ jsh.ResourceEditor = function(opt_domHelper) {
 
   /** @type {goog.ui.Component} */
   this.resourceProperties_;
+
+  /** @type {number} */
+  this.splitPaneHandleWidth_ = 5;
 };
 goog.inherits(jsh.ResourceEditor, goog.ui.Component);
 
@@ -35,7 +38,7 @@ goog.inherits(jsh.ResourceEditor, goog.ui.Component);
  */
 jsh.ResourceEditor.prototype.createDom = function() {
 
-  var el = this.dom_.createDom('div');
+  var el = this.dom_.createDom('div', {'class': 'jsh-resEditor'});
   this.decorateInternal(el);
 
 };
@@ -55,7 +58,29 @@ jsh.ResourceEditor.prototype.decorateInternal = function(element) {
   this.resourceProperties_ = new goog.ui.Component();
   this.splitPane_ = new jsh.SplitPane(this.editor_, this.resourceProperties_,
     goog.ui.SplitPane.Orientation.VERTICAL);
+  this.splitPane_.setInitialSize(300);
+  this.splitPane_.setHandleSize(this.splitPaneHandleWidth_);
+  this.splitPane_.setSecondComponentStatic(true);
 
   this.addChild(this.splitPane_, true);
+
+  goog.events.listen(this.getParent(), goog.ui.Component.EventType.CHANGE,
+      this.handleParentSizeChange, false, this);
+  goog.events.listen(this.splitPane_, goog.ui.Component.EventType.CHANGE,
+      goog.events.Event.stopPropagation, false, this);
+
 }
+
+
+/**
+ * Handler for when the parent component changes. We're interested in size
+ * changes in particular.
+ * @param {!goog.events.Event} e An event.
+ * @private
+ */
+jsh.ResourceEditor.prototype.handleParentSizeChange = function(e) {
+  var size = goog.style.getSize(this.getElement());
+  this.splitPane_.setSize(size);
+  this.editor_.resize();
+};
 

--- a/common-web/src/main/webapp/css/ide.css
+++ b/common-web/src/main/webapp/css/ide.css
@@ -50,3 +50,7 @@ body {
 .ace_gutter {
     border-radius: 10px 0 0 10px
 }
+
+.jsh-resEditor {
+    height: 100%;
+}


### PR DESCRIPTION
I've added a jsh.ResourceEditor class, and moved the event handling into there as well.  It all seems to work, though I'm not entirely sure why the ACE Editor successfully resizes when you move the inner splitpane handle.  I don't currently have a listener to do that on the inner split pane.  Will talk to you about it later.
