### PR TITLE
Load hack from sever.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ build
 
 # Glovr #
 .glovr
+
+# jshack-test-web root dir #
+/test-web/src/test/data/hacks

--- a/common-web/src/main/javascript/jsh/dataservice.js
+++ b/common-web/src/main/javascript/jsh/dataservice.js
@@ -84,11 +84,12 @@ jsh.DataService.prototype.getHack = function(id) {
 /**
  * Persist hack to server.
  * @param {jsh.model.Hack} hack the hack
+ * @return {jsh.async.Deferred} The hack.
  */
 jsh.DataService.prototype.saveHack = function(hack) {
   var dataServiceReq = new jsh.DataService.Request(
       new goog.async.Deferred(),
-      this.handleSaveResponse
+      this.unpackHackJSON
       );
 
   var requestId = this.putRequest_(dataServiceReq);
@@ -102,6 +103,8 @@ jsh.DataService.prototype.saveHack = function(hack) {
     this.xhrManager_.send(requestId, this.wsUrl_ + hack.identifier, 'PUT', json,
         {'Content-Type': 'application/json'});
   }
+
+  return dataServiceReq.deferred;
 };
 
 
@@ -147,13 +150,13 @@ jsh.DataService.prototype.packHackJSON = function(hack) {
 };
 
 
-/**
- *
- * @param {goog.events.Event!} e
- */
-jsh.DataService.prototype.handleSaveResponse = function(e) {
-  console.log('response!');
-};
+///**
+// *
+// * @param {goog.events.Event!} e
+// */
+//jsh.DataService.prototype.handleSaveResponse = function(e) {
+//  console.log('response!');
+//};
 
 
 /**

--- a/common-web/src/main/javascript/jsh/editorcontroller.js
+++ b/common-web/src/main/javascript/jsh/editorcontroller.js
@@ -29,5 +29,18 @@ jsh.EditorController = function(hackEditor, dataService) {
  * @param {goog.events.Event!} e the event
  */
 jsh.EditorController.prototype.handleSave = function(e) {
-  this.dataService_.saveHack(e.target.getHackModel());
+  var request = this.dataService_.saveHack(e.target.getHackModel());
+  request.addCallback(this.hackEditor_.updateEditorState, this.hackEditor_);
+  //todo: addErrback
+};
+
+
+/**
+ * Load a hack from the dataservice into the editor.
+ * @param {string} hackId The id of the hack to load.
+ */
+jsh.EditorController.prototype.loadHackById = function(hackId) {
+  var request = this.dataService_.getHack(hackId);
+  request.addCallback(this.hackEditor_.updateEditorState, this.hackEditor_);
+  //todo: addErrback
 };

--- a/common-web/src/main/javascript/main.js
+++ b/common-web/src/main/javascript/main.js
@@ -1,3 +1,4 @@
+goog.require('goog.Uri');
 goog.require('jsh.EditorController');
 goog.require('jsh.HackEditor');
 goog.require('jsh.model.Hack');
@@ -12,33 +13,40 @@ goog.events.listenOnce(window, goog.events.EventType.LOAD, function() {
   var mainEl = goog.dom.createDom('div', 'ide');
   goog.dom.appendChild(document.body, mainEl);
 
-  var hack = new jsh.model.Hack();
-  hack.name = 'Gradebook Column Protector';
-  hack.identifier = 'gbcolprotect';
-  hack.resources = new Array();
-
-  var cssRes = new jsh.model.HackResource();
-  cssRes.mime = 'text/css';
-  cssRes.path = 'gbcolprotect.css';
-  hack.resources.push(cssRes);
-
-  var jsRes = new jsh.model.HackResource();
-  jsRes.mime = 'application/javascript';
-  jsRes.path = 'gbcolprotect.js';
-  hack.resources.push(jsRes);
-
-  var pngRes = new jsh.model.HackResource();
-  pngRes.mime = 'image/png';
-  pngRes.path = 'lock.png';
-  hack.resources.push(pngRes);
+  //  var hack = new jsh.model.Hack();
+  //  hack.name = 'Gradebook Column Protector';
+  //  hack.identifier = 'gbcolprotect';
+  //  hack.resources = new Array();
+  //
+  //  var cssRes = new jsh.model.HackResource();
+  //  cssRes.mime = 'text/css';
+  //  cssRes.path = 'gbcolprotect.css';
+  //  hack.resources.push(cssRes);
+  //
+  //  var jsRes = new jsh.model.HackResource();
+  //  jsRes.mime = 'application/javascript';
+  //  jsRes.path = 'gbcolprotect.js';
+  //  hack.resources.push(jsRes);
+  //
+  //  var pngRes = new jsh.model.HackResource();
+  //  pngRes.mime = 'image/png';
+  //  pngRes.path = 'lock.png';
+  //  hack.resources.push(pngRes);
 
   var editor = new jsh.HackEditor();
   editor.decorate(mainEl);
 
-  editor.updateEditorState(hack);
+  //editor.updateEditorState(hack);
 
   var dataService = new jsh.DataService('/jshack-test-web');
 
   var controller = new jsh.EditorController(editor, dataService);
+
+  var uri = new goog.Uri(window.location);
+  var hackId = uri.getQueryData().get('hackid');
+
+  if (hackId) {
+    controller.loadHackById(hackId);
+  }
 
 });

--- a/common-web/src/main/soy/editor.soy
+++ b/common-web/src/main/soy/editor.soy
@@ -7,8 +7,20 @@
   */
 {template .resourceListHeader}
     <div class="{css jsh-resourcelistheader}">
-        <div class="{css jsh-resourcelistheader-hackname}">{$hackName}</div>
-        <div class="{css jsh-resourcelistheader-hackid}">{$hackId}</div>
+        <div class="{css jsh-resourcelistheader-hackname}">
+        {if $hackName}
+            {$hackName}
+        {else}
+            Unsaved
+        {/if}
+        </div>
+        <div class="{css jsh-resourcelistheader-hackid}">
+        {if $hackId}
+            {$hackId}
+        {else}
+            This hack has not been saved.
+        {/if}
+        </div>
     </div>
 {/template}
 

--- a/test-web/src/test/data/hacks/test/hack.xml
+++ b/test-web/src/test/data/hacks/test/hack.xml
@@ -1,8 +1,0 @@
-<hack>
-  <name>test blah</name>
-  <identifier>test</identifier>
-  <description>blah</description>
-  <version>1</version>
-  <targetVersionMin>1</targetVersionMin>
-  <targetVersionMax>2</targetVersionMax>
-</hack>


### PR DESCRIPTION
Hacks can now be loaded from the server using the query string param "hackid".
The response from the server when saving a hack is now used to refresh the state of the editor.
Ignored the jshack-common-web application root directory so that hacks created during testing don't get added to git. Consider moving this directory to the build directory.
