### PR TITLE
Changed list selection behaviour when deleting resources

### DIFF
--- a/common-web/src/main/javascript/jsh/editor.js
+++ b/common-web/src/main/javascript/jsh/editor.js
@@ -461,7 +461,8 @@ jsh.HackEditor.prototype.deleteSelectedResource = function() {
     var selectedIndex = this.resourceListContainer_.getSelectedIndex();
     this.resourceListContainer_.removeChild(resItem, true);
     if (selectedIndex >= this.resourceListContainer_.getChildCount()) {
-      this.resourceListContainer_.setSelectedChildByIndex(selectedIndex - 1, true);
+      this.resourceListContainer_.setSelectedChildByIndex(selectedIndex - 1,
+          true);
     } else {
       this.resourceListContainer_.setSelectedChildByIndex(selectedIndex, true);
     }


### PR DESCRIPTION
This implements the change of behaviour that we discussed.  Unless you're deleting the last item, the selection index now stays the same, instead of moving up the list. 
I'm not sure if this is the best place for this code.  Maybe it should be moved in the ResourceListContainer class.
