### PR TITLE
Increase the Ace text size to match the editor.

### DIFF
--- a/common-web/src/main/css/ide.css
+++ b/common-web/src/main/css/ide.css
@@ -270,3 +270,7 @@ h2 {
 :-ms-input-placeholder {
     color: #505050;
 }
+
+.ace-editor {
+    font-size: inherit !important;
+}


### PR DESCRIPTION
Used the !important modifier in the CSS to override changes that to the text size that come in with the theme.
